### PR TITLE
Fixed bad config as a result of "(null)" occurrances in SMC

### DIFF
--- a/machines/imac12,1.conf
+++ b/machines/imac12,1.conf
@@ -269,8 +269,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		}
 	);

--- a/machines/imac12,2.conf
+++ b/machines/imac12,2.conf
@@ -269,8 +269,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		}
 	);

--- a/machines/imac13,1.conf
+++ b/machines/imac13,1.conf
@@ -185,8 +185,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac13,2.conf
+++ b/machines/imac13,2.conf
@@ -292,8 +292,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac14,1.conf
+++ b/machines/imac14,1.conf
@@ -187,8 +187,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac14,2.conf
+++ b/machines/imac14,2.conf
@@ -276,8 +276,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac14,3.conf
+++ b/machines/imac14,3.conf
@@ -187,8 +187,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac14,4.conf
+++ b/machines/imac14,4.conf
@@ -209,8 +209,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac15,1.conf
+++ b/machines/imac15,1.conf
@@ -213,8 +213,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac16,1.conf
+++ b/machines/imac16,1.conf
@@ -137,8 +137,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac16,2.conf
+++ b/machines/imac16,2.conf
@@ -157,8 +157,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac17,1.conf
+++ b/machines/imac17,1.conf
@@ -129,8 +129,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac18,1.conf
+++ b/machines/imac18,1.conf
@@ -177,8 +177,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac18,2.conf
+++ b/machines/imac18,2.conf
@@ -201,8 +201,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/imac18,3.conf
+++ b/machines/imac18,3.conf
@@ -237,8 +237,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/macbookpro11,1.conf
+++ b/machines/macbookpro11,1.conf
@@ -165,8 +165,6 @@ profile =
 		},
 		{
 			sensor = "CUS1";
-			floor = (null);
-			ceiling = (null);
 			value = "CPU Cores";
 		},
 		{

--- a/machines/macbookpro5,4.conf
+++ b/machines/macbookpro5,4.conf
@@ -130,8 +130,6 @@ profile =
 		},
 		{
 			sensor = "PD0R";
-			floor = (null);
-			ceiling = (null);
 			value = "DC In";
 		}
 	);

--- a/machines/macbookpro8,1.conf
+++ b/machines/macbookpro8,1.conf
@@ -161,8 +161,6 @@ profile =
 		},
 		{
 			sensor = "PD0R";
-			floor = (null);
-			ceiling = (null);
 			value = "DC In";
 		},
 		{

--- a/machines/macbookpro8,2.conf
+++ b/machines/macbookpro8,2.conf
@@ -226,8 +226,6 @@ profile =
 		},
 		{
 			sensor = "PD0R";
-			floor = (null);
-			ceiling = (null);
 			value = "DC In";
 		},
 		{

--- a/util/genprofile.pl
+++ b/util/genprofile.pl
@@ -117,11 +117,11 @@ sub gen_profile {
         print $FH "\t\t{\n\t\t\t";
         print $FH "sensor = \"".$sensors[$i]->{key}."\";\n\t\t\t";
         
-        if ($sensors[$i]->{low}) {
+        if ($sensors[$i]->{low} and $sensors[$i]->{low} ne "(null)") {
             print $FH "floor = ".$sensors[$i]->{low}.";\n\t\t\t";
         }
 
-        if ($sensors[$i]->{high}) {
+        if ($sensors[$i]->{high} and $sensors[$i]->{high} ne "(null)") {
             print $FH "ceiling = ".$sensors[$i]->{high}.";\n\t\t\t";
         }
 


### PR DESCRIPTION
Application will error when trying to read a config file that contains "(null)" as a value.